### PR TITLE
slugid.nice() now returns unicode strings

### DIFF
--- a/maven_lambda/metadata.py
+++ b/maven_lambda/metadata.py
@@ -288,7 +288,7 @@ def invalidate_cloudfront(path):
 
     if distribution_id:
         path = path if path.startswith('/') else '/{}'.format(path)
-        request_id = slugid.nice().decode('utf-8')  # nice() returns bytes by default
+        request_id = slugid.nice()
 
         try:
             cloudfront.create_invalidation(

--- a/maven_lambda/test/test_metadata.py
+++ b/maven_lambda/test/test_metadata.py
@@ -404,7 +404,7 @@ def test_invalidate_cloudfront(monkeypatch, cloudfront_distribution_id):
     cloudfront_mock = MagicMock()
     monkeypatch.setattr('maven_lambda.metadata.cloudfront', cloudfront_mock)
     monkeypatch.setattr('os.environ.get', lambda _, __: cloudfront_distribution_id)
-    monkeypatch.setattr('slugid.nice', lambda: b'some_-Known_-_Slug--Id')
+    monkeypatch.setattr('slugid.nice', lambda: 'some_-Known_-_Slug--Id')
 
     invalidate_cloudfront('some/folder/some_file')
 


### PR DESCRIPTION
#18 bumped dependencies, including [slugid](https://github.com/mozilla-releng/maven-lambda/pull/18/files#diff-7fe11226cff646f5d9f35faa76217059R46). Slugid 2.0.0 now returns unicode strings: https://github.com/taskcluster/slugid.py/commit/162b30c6670d7878a5aabb5374857e7faff5ffdb