### PR TITLE
Set a Cache-Control header on the metadata files

### DIFF
--- a/maven_lambda/metadata.py
+++ b/maven_lambda/metadata.py
@@ -223,7 +223,8 @@ def get_latest_version(versions_per_path):
 def upload_s3_file(bucket_name, folder, file_name, data, content_type='text/plain'):
     folder = folder.rstrip('/')
     key = '{}/{}'.format(folder, file_name)
-    s3.Object(bucket_name, key).put(Body=data, ContentType=content_type)
+    s3.Object(bucket_name, key).put(Body=data, ContentType=content_type,
+                                    CacheControl='max-age=600')
     return key
 
 

--- a/maven_lambda/test/integration/test_integration.py
+++ b/maven_lambda/test/integration/test_integration.py
@@ -226,11 +226,11 @@ def test_metadata_lambda_handler(monkeypatch, inserted_key, bucket_keys, expecte
 
     for expected_item in expected_metadata.values():
         assert call('some_bucket_name', expected_item['xml_key']) in s3_mock.Object.call_args_list
-        assert call(Body=expected_item['xml_data'], ContentType='text/xml') in object_mock.put.call_args_list
+        assert call(Body=expected_item['xml_data'], ContentType='text/xml', CacheControl='max-age=600') in object_mock.put.call_args_list
         assert call('some_bucket_name', expected_item['md5_key']) in s3_mock.Object.call_args_list
-        assert call(Body=expected_item['md5_data'], ContentType='text/plain') in object_mock.put.call_args_list
+        assert call(Body=expected_item['md5_data'], ContentType='text/plain', CacheControl='max-age=600') in object_mock.put.call_args_list
         assert call('some_bucket_name', expected_item['sha1_key']) in s3_mock.Object.call_args_list
-        assert call(Body=expected_item['sha1_data'], ContentType='text/plain') in object_mock.put.call_args_list
+        assert call(Body=expected_item['sha1_data'], ContentType='text/plain', CacheControl='max-age=600') in object_mock.put.call_args_list
 
     expected_call_count = len(expected_metadata) * 3
     assert s3_mock.Object.call_count == expected_call_count

--- a/maven_lambda/test/test_metadata.py
+++ b/maven_lambda/test/test_metadata.py
@@ -329,7 +329,7 @@ def test_upload_s3_file(monkeypatch):
     ) == 'some/folder/some_file'
 
     s3_mock.Object.assert_called_once_with('some_bucket', 'some/folder/some_file')
-    object_mock.put.assert_called_once_with(Body='some data', ContentType='some/content-type')
+    object_mock.put.assert_called_once_with(Body='some data', ContentType='some/content-type', CacheControl='max-age=600')
 
 
 @pytest.mark.parametrize('cloudfront_distribution_id, paths, expected_items, expected_quantity', ((


### PR DESCRIPTION
In case our invalidation request fails for some reason, avoid falling back to
the default cloudfront ttl for our maven metadata, and have it refresh
after 10 minutes instead.